### PR TITLE
Check advanced ClojureScript warnings in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CITests",
   "description": "Testing",
   "scripts": {
-    "ci-test": "npx shadow-cljs compile ci && npx karma start --single-run"
+    "ci-test": "npx shadow-cljs release ci && npx karma start --single-run"
   },
   "devDependencies": {
     "karma": "^6.4.1",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -20,4 +20,8 @@
   
   :ci
   {:target :karma
-   :output-to "target/ci.js"}}}
+   :output-to "target/ci.js"
+   :compiler-options {:warnings-as-errors true
+                      ;; core.async emits terminal expressions in generated
+                      ;; state machines that Closure reports as useless code.
+                      :closure-warnings {:useless-code :off}}}}}


### PR DESCRIPTION
Makes the Karma job use release/advanced compilation and fail on actionable ClojureScript warnings. Closure's useless-code diagnostic remains narrowly disabled because it points at generated core.async state-machine code. Verified: advanced build completed with 0 warnings; 20 Karma tests passed.