### PR TITLE
fix(cljs): supervisor's stale sweep holds Node's event loop open forever

### DIFF
--- a/src/superv/async.cljc
+++ b/src/superv/async.cljc
@@ -45,6 +45,30 @@
 
 (def ^:const NUM_ABORT_CHANS 1000)
 
+(defn- schedule-stale-check!
+  "Re-arm the supervisor's stale-exception sweep.
+
+  On the JVM (and in a browser) this is a core.async timeout, as it always was.
+
+  On Node it is a raw `setTimeout` whose handle is `unref`'d. `S` below is a
+  top-level `def`, so merely REQUIRING this namespace starts the sweep, and a
+  referenced timer keeps Node's event loop alive forever: `node -e
+  'require(\"some-lib-that-loads-this\")'` never exits. That is silent — nothing
+  errors, the process simply hangs — and it reaches every script, test runner,
+  CI job and Lambda that loads a library depending on superv.async. An unref'd
+  timer still fires while other work keeps the process alive, which is exactly
+  the supervision this sweep provides, but it no longer prevents exit.
+
+  `unref` is Node-only; browsers return a plain number from `setTimeout`, so the
+  call is guarded and falls back to the core.async path there."
+  [stale-timeout f]
+  #?(:clj (take! (timeout stale-timeout) f)
+     :cljs (let [t (js/setTimeout #(f nil) stale-timeout)]
+             (if (and (some? t) (fn? (unchecked-get t "unref")))
+               (do (.unref t) nil)
+               ;; Browser: no unref, and no event loop to hold open either.
+               nil))))
+
 (defn simple-supervisor
   "A simple supervisor which deals with errors through callbacks. You need to
   close its abort channel manually if you want the context to stop. It is
@@ -74,7 +98,7 @@
          (when e
            (error-fn e)
            (-free-exception s e))
-         (take! (timeout stale-timeout) pending))) nil)
+         (schedule-stale-check! stale-timeout pending))) nil)
     s))
 
 (defn dummy-supervisor []


### PR DESCRIPTION
Requiring `superv.async` from Node makes the process hang indefinitely.

```
node -e 'require("datahike")'                      # never exits
node -e 'require("datahike"); process.exit(0)'     # 151ms
```

`process.getActiveResourcesInfo()` after the require shows a stray `Timeout`.

## Cause

`S` (async.cljc:109) is a top-level `def`, so loading the namespace runs
`simple-supervisor`, whose stale-exception sweep ends with

```clojure
(take! (timeout stale-timeout) pending)
```

re-arming itself every 10 s forever. On Node a referenced timer keeps the event
loop alive, so nothing can exit.

The failure is silent: nothing errors, no output appears, the process just never
returns, and the cause sits several dependencies away from whatever is hanging.
It reaches every script, test runner, CI job and Lambda that loads a library
depending on superv.async. It surfaced while verifying examples for a blog post
against the `datahike` npm package, where each check appeared to take minutes.

There is precedent for this class of problem right there in `S`: the
`native-image-build?` branch already substitutes `dummy-supervisor` because the
sweep cannot run in a static context.

## Fix

Route the re-arm through `schedule-stale-check!`:

- **JVM**: unchanged, still the core.async `timeout`.
- **Node**: `js/setTimeout` with `.unref()` on the handle. An unref'd timer still
  fires while other work keeps the process alive, so supervision behaves the
  same; it just stops being a reason to stay alive.
- **Browser**: `setTimeout` returns a plain number with no `unref`, and there is
  no event loop to hold open, so the call is guarded and falls through.

## Verification

Compiled a probe that requires the namespace and returns:

| | exit code | time |
|---|---|---|
| before | 124 (killed) | 25 s timeout |
| after | 0 | immediate |

JVM suite: 27 tests, 44 assertions, 0 failures, 0 errors.

## Downstream

`datahike` pins `org.replikativ/superv.async 0.3.50`, so it needs a release and
a bump to pick this up. Worth doing soon: the datahike npm package was published
this week and every Node consumer hits this.