### PR TITLE
Export a clj-kondo configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ local*
 figwheel_server.log
 /.shadow-cljs
 /public
-/resources
+/resources/public
 .cpcache
 /.calva
 out

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+- export a clj-kondo configuration. The macros take a supervisor as their
+  first argument, which clj-kondo cannot interpret on its own: `go-loop-try`,
+  `go-loop-try-`, `go-loop-super` and `go-for` put it where the binding vector
+  is expected, so every loop binding was reported as an unresolved symbol and
+  every `recur` as the wrong arity. Hooks rewrite those calls into the forms
+  the macros expand to, and the `[S & body]` macros are declared `:lint-as do`.
+  A consumer picks this up with `clj-kondo --copy-configs`, which lets a
+  project with these macros run lint as a build gate.
+
 ## 0.2.8
 - fix too many pending takes on abort-ch
 - add reduce<

--- a/resources/clj-kondo.exports/org.replikativ/superv.async/config.edn
+++ b/resources/clj-kondo.exports/org.replikativ/superv.async/config.edn
@@ -1,0 +1,16 @@
+;; Exported to consumers. superv.async's macros take a supervisor as their
+;; first argument, which clj-kondo cannot interpret on its own: the forms with
+;; a binding vector then report every binding as an unresolved symbol and every
+;; `recur` as the wrong arity, and a project that lints as a gate cannot pass.
+{:hooks {:analyze-call {superv.async/go-loop-try   hooks.superv-async/go-loop
+                        superv.async/go-loop-try-  hooks.superv-async/go-loop
+                        superv.async/go-loop-super hooks.superv-async/go-loop
+                        superv.async/go-for        hooks.superv-async/go-for}}
+ ;; The rest take `[S & body]` and evaluate the supervisor, so `do` describes
+ ;; them exactly.
+ :lint-as {superv.async/go-try      clojure.core/do
+           superv.async/go-try-     clojure.core/do
+           superv.async/go-super    clojure.core/do
+           superv.async/thread-try   clojure.core/do
+           superv.async/thread-super clojure.core/do
+           superv.async/restarting-supervisor clojure.core/do}}

--- a/resources/clj-kondo.exports/org.replikativ/superv.async/hooks/superv_async.clj
+++ b/resources/clj-kondo.exports/org.replikativ/superv.async/hooks/superv_async.clj
@@ -1,0 +1,23 @@
+(ns hooks.superv-async
+  "clj-kondo hooks for the macros that take a supervisor before a binding form.
+
+   `(go-loop-try S [i 0] …)` puts the supervisor where `loop` expects its
+   bindings, so without help clj-kondo cannot see `i` and reports every loop
+   variable as unresolved and every `recur` as the wrong arity. Each hook
+   rewrites the call into the ordinary form plus the supervisor as an
+   expression, which is what the macro expands to anyway."
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn- supervised
+  "`(macro S rest…)` as `(do S (target rest…))`."
+  [target {:keys [node]}]
+  (let [[_ supervisor & more] (:children node)]
+    (if (nil? supervisor)
+      {:node node}
+      {:node (api/list-node
+              (list (api/token-node 'do)
+                    supervisor
+                    (api/list-node (list* (api/token-node target) more))))})))
+
+(defn go-loop [ctx] (supervised 'clojure.core/loop ctx))
+(defn go-for [ctx] (supervised 'clojure.core/for ctx))


### PR DESCRIPTION
## Why

superv.async's macros take the supervisor as their first argument. clj-kondo cannot know that, so for the four that also take a binding vector, `go-loop-try`, `go-loop-try-`, `go-loop-super` and `go-for`, it reads the supervisor as the bindings and then reports every loop binding as an unresolved symbol and every `recur` as the wrong arity.

That is not cosmetic. In kabel it accounts for 64 of 67 lint errors on otherwise clean code, which is the difference between being able to run lint as a build gate and not. Every project in the stack that uses these macros has the same problem, so the fix belongs here rather than copied into each of them.

## What

- `resources/clj-kondo.exports/org.replikativ/superv.async/`, with hooks that rewrite the four binding forms into what the macros expand to, `(do S (loop …))` and `(do S (for …))`, so the supervisor is still analysed as an expression and the bindings become visible.
- The `[S & body]` macros, `go-try`, `go-try-`, `go-super`, `thread-try`, `thread-super` and `restarting-supervisor`, are declared `:lint-as clojure.core/do`, which describes them exactly.

A consumer picks this up with `clj-kondo --copy-configs`.

`.gitignore` ignored all of `/resources`, which would have silently kept the exported files out of the jar; it now ignores the build output under it instead.

## Effect

superv.async lints with 0 errors. In kabel, with this imported: 67 errors down to 1, and that one turned out to be a real oversight in a `.cljs` namespace rather than a false positive.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3
